### PR TITLE
feat: adds .hbs HTML language extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export const HTML_LANGUAGES: string[] = [
   'erb',
   'haml',
   'handlebars',
+  'hbs',
   'html',
   'HTML (Eex)',
   'HTML (EEx)',


### PR DESCRIPTION
Thanks for the great extension! This PR adds `hbs` as a valid HTML language extension, most commonly used by [Ember.js](https://emberjs.com/) developers using Tailwind in HTMLBars templates.

---

For use before this PR is merged and released:

```
npm install -g vsce
git clone -b feat/add-hbs-html-language git@github.willviles/vscode-tailwindcss.git
cd vscode-tailwindcss
npm install
vsce package
```

Then install the generated .vsix file by running the VSCode command 'Extensions: Install from VSIX...'