### PR TITLE
Add additional Elixir eex languages

### DIFF
--- a/packages/tailwindcss-language-server/src/util/html.ts
+++ b/packages/tailwindcss-language-server/src/util/html.ts
@@ -12,6 +12,8 @@ export const HTML_LANGUAGES = [
   'hbs',
   'html',
   'HTML (Eex)',
+  'HTML (EEx)',
+  'html-eex',
   'jade',
   'leaf',
   'liquid',

--- a/packages/tailwindcss-vscode/src/lib/languages.ts
+++ b/packages/tailwindcss-vscode/src/lib/languages.ts
@@ -11,6 +11,8 @@ export const LANGUAGES = [
   'hbs',
   'html',
   'HTML (Eex)',
+  'HTML (EEx)',
+  'html-eex',
   'jade',
   'leaf',
   'liquid',


### PR DESCRIPTION
Hello!
So there's an interesting amount of language ids involved in supporting HTML (Eex) for `html.eex` and `html.leex` files.
The original Language ID was `HTML (Eex)` which was then replaced with `HTML (EEx)` in a future plugin.

New Identifier Guidelines for language ids specify lowercase identifiers with no spaces.
https://code.visualstudio.com/docs/languages/identifiers#_new-identifier-guidelines

This will hopefully be corrected with:
https://github.com/elixir-lsp/vscode-elixir-ls/pull/87

By supporting `HTML (Eex)` and `HTML (EEx)` you can support both the legacy Elixir plugin as well as the current language service plugin.

By supporting `html-eex` you will avoid the plugin suddenly not working when the language id change in the new plugin takes place.