### PR TITLE
Add SugarSS support

### DIFF
--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -31,6 +31,7 @@ export const DEFAULT_LANGUAGES = [
   'sass',
   'scss',
   'stylus',
+  'sugarss',
   // js
   'javascript',
   'javascriptreact',

--- a/src/lsp/util/css.ts
+++ b/src/lsp/util/css.ts
@@ -9,6 +9,7 @@ export const CSS_LANGUAGES = [
   'sass',
   'scss',
   'stylus',
+  'sugarss',
 ]
 
 function isCssDoc(state: State, doc: TextDocument): boolean {


### PR DESCRIPTION
[SugarSS](https://github.com/postcss/sugarss) is an indent-based CSS syntax for PostCSS.

SugarSS MIME-type is `text/x-sugarss` with `.sss` file extension.